### PR TITLE
WinAPI changes

### DIFF
--- a/OBSNotifier/App.xaml.cs
+++ b/OBSNotifier/App.xaml.cs
@@ -469,20 +469,29 @@ namespace OBSNotifier
 
         static void UpdateTrayStatus()
         {
-            switch (CurrentConnectionState)
+            try
             {
-                case ConnectionState.Connected:
-                    trayIcon.Icon = OBSNotifier.Properties.Resources.obs_notifier_connected_64px;
-                    trayIcon.Text = $"{AppNameSpaced}:\n{Utils.Tr("tray_menu_status_connected")}";
-                    break;
-                case ConnectionState.Disconnected:
-                    trayIcon.Icon = OBSNotifier.Properties.Resources.obs_notifier_64px;
-                    trayIcon.Text = $"{AppNameSpaced}:\n{Utils.Tr("tray_menu_status_not_connected")}";
-                    break;
-                case ConnectionState.TryingToReconnect:
-                    trayIcon.Icon = OBSNotifier.Properties.Resources.obs_notifier_reconnect_64px;
-                    trayIcon.Text = $"{AppNameSpaced}:\n{Utils.Tr("tray_menu_status_trying_to_reconnect")}";
-                    break;
+                // max 64 chars
+                switch (CurrentConnectionState)
+                {
+                    case ConnectionState.Connected:
+                        trayIcon.Icon = OBSNotifier.Properties.Resources.obs_notifier_connected_64px;
+                        trayIcon.Text = $"{AppNameSpaced}:\n{Utils.Tr("tray_menu_status_connected")}";
+                        break;
+                    case ConnectionState.Disconnected:
+                        trayIcon.Icon = OBSNotifier.Properties.Resources.obs_notifier_64px;
+                        trayIcon.Text = $"{AppNameSpaced}:\n{Utils.Tr("tray_menu_status_not_connected")}";
+                        break;
+                    case ConnectionState.TryingToReconnect:
+                        trayIcon.Icon = OBSNotifier.Properties.Resources.obs_notifier_reconnect_64px;
+                        trayIcon.Text = $"{AppNameSpaced}:\n{Utils.Tr("tray_menu_status_trying_to_reconnect")}";
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log(ex);
+                trayIcon.Text = $"{AppNameSpaced}";
             }
         }
 

--- a/OBSNotifier/Modules/Default/DefaultCustomNotifBlockSettings.cs
+++ b/OBSNotifier/Modules/Default/DefaultCustomNotifBlockSettings.cs
@@ -24,7 +24,8 @@ namespace OBSNotifier.Modules.Default
         public double Height { get { return height; } set { height = Math.Max(1, value); } }
         public Thickness Margin { get; set; }
         public uint MaxPathChars { get; set; }
-        public bool ShowQuickActionsOnFileSave { get; set; }
+        public bool ClickThrough { get; set; }
+        public bool ShowQuickActions { get; set; }
 
         public DefaultCustomNotifBlockSettings()
         {
@@ -38,7 +39,8 @@ namespace OBSNotifier.Modules.Default
             Height = 52;
             Margin = new Thickness(4);
             MaxPathChars = 32;
-            ShowQuickActionsOnFileSave = true;
+            ClickThrough = false;
+            ShowQuickActions = true;
         }
     }
 }

--- a/OBSNotifier/Modules/Default/DefaultNotification.cs
+++ b/OBSNotifier/Modules/Default/DefaultNotification.cs
@@ -27,7 +27,7 @@ namespace OBSNotifier.Modules.Default
         OBSNotifierModuleSettings _moduleSettings = new OBSNotifierModuleSettings()
         {
             UseSafeDisplayArea = true,
-            AdditionalData = "BackgroundColor = #FF4C4C4C\nOutlineColor = #59000000\nTextColor = #FFD8D8D8\nBlocks = 3\nRadius = 4.0\nWidth = 180.0\nHeight = 52.0\nMargin = 4, 4, 4, 4\nMaxPathChars = 32\nShowQuickActionsOnFileSave = True",
+            AdditionalData = "BackgroundColor = #FF4C4C4C\nOutlineColor = #59000000\nTextColor = #FFD8D8D8\nBlocks = 3\nRadius = 4.0\nWidth = 180.0\nHeight = 52.0\nMargin = 4, 4, 4, 4\nMaxPathChars = 32\nClickThrough = False\nShowQuickActions = True",
             Option = Positions.BottomRight,
             Offset = new Point(0, 0),
             OnScreenTime = 3000,

--- a/OBSNotifier/Modules/Default/DefaultNotificationBlock.xaml.cs
+++ b/OBSNotifier/Modules/Default/DefaultNotificationBlock.xaml.cs
@@ -48,7 +48,7 @@ namespace OBSNotifier.Modules.Default
             var notif = NotificationType.None;
             if (isPreview && (
                 (prevMaxPathChars != -1 && prevMaxPathChars != settings.MaxPathChars) ||
-                (prevShowQuickActions != null && prevShowQuickActions != settings.ShowQuickActionsOnFileSave)
+                (prevShowQuickActions != null && prevShowQuickActions != settings.ShowQuickActions)
                ))
             {
                 desc = Utils.GetShortPath(@"D:\Lorem\ipsum\dolor\sit\amet\consectetur\adipiscing\elit.\Donec\pharetra\lorem\turpis\nec\fringilla\leo\interdum\sit\amet.\Mauris\in\placerat\nulla\in\laoreet\Videos\OBS\01.01.01\Replay_01-01-01.mkv", settings.MaxPathChars);
@@ -112,7 +112,7 @@ namespace OBSNotifier.Modules.Default
             fileOpenOverlay.IsPreview = isPreview;
             if (type != NotificationType.None && NotificationType.WithFilePaths.HasFlag(type))
             {
-                if (settings.ShowQuickActionsOnFileSave)
+                if (settings.ShowQuickActions)
                 {
                     fileOpenOverlay.FilePath = desc;
                     fileOpenOverlay.Clip = new RectangleGeometry(new Rect(0, 0, Width, Height), r_notif.RadiusX, r_notif.RadiusY);
@@ -133,7 +133,7 @@ namespace OBSNotifier.Modules.Default
             l_desc.Visibility = string.IsNullOrWhiteSpace(l_desc.Text) ? Visibility.Collapsed : Visibility.Visible;
 
             prevMaxPathChars = (int)settings.MaxPathChars;
-            prevShowQuickActions = settings.ShowQuickActionsOnFileSave;
+            prevShowQuickActions = settings.ShowQuickActions;
         }
 
         private void Window_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/OBSNotifier/Modules/Default/DefaultNotificationWindow.xaml
+++ b/OBSNotifier/Modules/Default/DefaultNotificationWindow.xaml
@@ -6,11 +6,11 @@
         xmlns:local="clr-namespace:OBSNotifier.Modules.Default"
         mc:Ignorable="d" x:ClassModifier="internal"
         Title="Default Notification"
-        WindowStyle="None" AllowsTransparency="True" Topmost="True" ShowActivated="False" ResizeMode="NoResize" ShowInTaskbar="False"
+        WindowStyle="None" AllowsTransparency="True" Topmost="True" ResizeMode="NoResize" ShowInTaskbar="False"
+        ShowActivated="False" Focusable="False" FocusManager.IsFocusScope="False"
         Opacity="1.0"
         Width="180" Height="104"
-        Background="{x:Null}"
-        Loaded="Window_Loaded">
+        Background="{x:Null}">
 
     <StackPanel x:Name="sp_main_panel" VerticalAlignment="Bottom">
         <local:DefaultNotificationBlock/>

--- a/OBSNotifier/Modules/Default/DefaultNotificationWindow.xaml.cs
+++ b/OBSNotifier/Modules/Default/DefaultNotificationWindow.xaml.cs
@@ -27,9 +27,13 @@ namespace OBSNotifier.Modules.Default
             owner = module;
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        protected override void OnSourceInitialized(EventArgs e)
         {
-            Utils.RemoveWindowFromAltTab(this);
+            base.OnSourceInitialized(e);
+
+            var hwnd = this.GetHandle();
+            UtilsWinApi.SetWindowIgnoreFocus(hwnd, true);
+            UtilsWinApi.SetWindowTopmost(hwnd, true);
         }
 
         protected override void OnClosed(EventArgs e)
@@ -53,6 +57,8 @@ namespace OBSNotifier.Modules.Default
 
                 RemoveUnusedBlocks();
             }
+
+            UtilsWinApi.SetWindowIgnoreMouse(this.GetHandle(), currentNotifBlockSettings.ClickThrough && !currentNotifBlockSettings.ShowQuickActions);
 
             CurrentNotifBlockSettings.Duration = owner.ModuleSettings.OnScreenTime;
             Height = CurrentNotifBlockSettings.Height * CurrentNotifBlockSettings.Blocks;

--- a/OBSNotifier/Modules/Nvidia-like/NvidiaCustomAnimationConfig.cs
+++ b/OBSNotifier/Modules/Nvidia-like/NvidiaCustomAnimationConfig.cs
@@ -29,6 +29,7 @@ namespace OBSNotifier.Modules.NvidiaLike
         public double Scale { get => scale; set => scale = Math.Max(0.001, value); }
 
         public uint MaxPathChars { get; set; }
+        public bool ClickThrough { get; set; }
         public bool ShowQuickActions { get; set; }
         public bool ShowQuickActionsColoredLine { get; set; }
         public double QuickActionsOffset { get => openFileOffset; set => openFileOffset = Math.Max(0, value); }
@@ -53,6 +54,7 @@ namespace OBSNotifier.Modules.NvidiaLike
             Scale = 1.0;
 
             MaxPathChars = 32;
+            ClickThrough = false;
             ShowQuickActions = true;
             ShowQuickActionsColoredLine = true;
             QuickActionsOffset = 8.0;
@@ -93,6 +95,7 @@ namespace OBSNotifier.Modules.NvidiaLike
                 Scale = this.Scale,
 
                 MaxPathChars = this.MaxPathChars,
+                ClickThrough = this.ClickThrough,
                 ShowQuickActions = this.ShowQuickActions,
                 ShowQuickActionsColoredLine = this.ShowQuickActionsColoredLine,
                 QuickActionsOffset = this.QuickActionsOffset,

--- a/OBSNotifier/Modules/Nvidia-like/NvidiaNotification.cs
+++ b/OBSNotifier/Modules/Nvidia-like/NvidiaNotification.cs
@@ -25,7 +25,7 @@ namespace OBSNotifier.Modules.NvidiaLike
         OBSNotifierModuleSettings _moduleSettings = new OBSNotifierModuleSettings()
         {
             UseSafeDisplayArea = true,
-            AdditionalData = "BackgroundColor = #2E48BD\nForegroundColor = #000000\nTextColor = #E4E4E4\nSlideDuration = 400\nSlideOffset = 180\nLineWidth = 6.0\nScale = 1.0\nMaxPathChars = 32\nShowQuickActions = True\nShowQuickActionsColoredLine = True\nQuickActionsOffset = 8.0\nIconHeight = 64.0\nIconPath = INVALID_PATH",
+            AdditionalData = "BackgroundColor = #2E48BD\nForegroundColor = #000000\nTextColor = #E4E4E4\nSlideDuration = 400\nSlideOffset = 180\nLineWidth = 6.0\nScale = 1.0\nMaxPathChars = 32\nClickThrough = False\nShowQuickActions = True\nShowQuickActionsColoredLine = True\nQuickActionsOffset = 8.0\nIconHeight = 64.0\nIconPath = INVALID_PATH",
             Option = Positions.TopRight,
             Offset = new Point(0, 0.1),
             OnScreenTime = 3000,

--- a/OBSNotifier/Modules/Nvidia-like/NvidiaNotificationWindow.xaml
+++ b/OBSNotifier/Modules/Nvidia-like/NvidiaNotificationWindow.xaml
@@ -6,11 +6,12 @@
         xmlns:uc="clr-namespace:OBSNotifier.Modules.UserControls"
         mc:Ignorable="d"
         Title="Nvidia Notification"
-        WindowStyle="None" AllowsTransparency="True" Topmost="True" ShowActivated="False" ResizeMode="NoResize" ShowInTaskbar="False"
+        WindowStyle="None" AllowsTransparency="True" Topmost="True"
+        ShowActivated="False" Focusable="False" FocusManager.IsFocusScope="False"
+        ResizeMode="NoResize" ShowInTaskbar="False"
         Opacity="1.0" SnapsToDevicePixels="True"
         Background="{x:Null}"
-        MouseDown="Window_MouseDown"
-        Loaded="Window_Loaded">
+        MouseDown="Window_MouseDown">
 
     <Window.Resources>
         <BeginStoryboard x:Key="nvidia_anim">

--- a/OBSNotifier/Modules/Nvidia-like/NvidiaNotificationWindow.xaml.cs
+++ b/OBSNotifier/Modules/Nvidia-like/NvidiaNotificationWindow.xaml.cs
@@ -37,9 +37,13 @@ namespace OBSNotifier.Modules.NvidiaLike
             i_icon.SizeChanged += I_icon_SizeChanged;
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        protected override void OnSourceInitialized(EventArgs e)
         {
-            Utils.RemoveWindowFromAltTab(this);
+            base.OnSourceInitialized(e);
+
+            var hwnd = this.GetHandle();
+            UtilsWinApi.SetWindowIgnoreFocus(hwnd, true);
+            UtilsWinApi.SetWindowTopmost(hwnd, true);
         }
 
         protected override void OnClosed(EventArgs e)
@@ -96,6 +100,8 @@ namespace OBSNotifier.Modules.NvidiaLike
             // General params
             currentParams.Duration = owner.ModuleSettings.OnScreenTime;
             currentParams.IsOnRightSide = (NvidiaNotification.Positions)owner.ModuleSettings.Option == NvidiaNotification.Positions.TopRight;
+
+            UtilsWinApi.SetWindowIgnoreMouse(this.GetHandle(), currentParams.ClickThrough && !currentParams.ShowQuickActions);
 
             fileOpenOverlay.IsPreview = currentParams.IsPreviewNotif;
             fileOpenOverlay.HorizontalAlignment = currentParams.IsOnRightSide ? HorizontalAlignment.Right : HorizontalAlignment.Left;

--- a/OBSNotifier/OBSNotifier.csproj
+++ b/OBSNotifier/OBSNotifier.csproj
@@ -37,6 +37,9 @@
   <PropertyGroup>
     <ApplicationIcon>Images\icon.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -119,6 +122,7 @@
       <DependentUpon>OpenFileOverlayActions.xaml</DependentUpon>
     </Compile>
     <Compile Include="Settings.cs" />
+    <Compile Include="UtilsWinApi.cs" />
     <Compile Include="UtilsConfigParser.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="VersionCheckGitHub.cs" />
@@ -453,4 +457,7 @@
     <Resource Include="Modules\Nvidia-like\obs.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>taskkill /F /IM $(TargetFileName) /FI "STATUS eq RUNNING"</PreBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OBSNotifier/UtilsWinApi.cs
+++ b/OBSNotifier/UtilsWinApi.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+
+namespace OBSNotifier
+{
+    public static class UtilsWinApi
+    {
+        public static IntPtr GetHandle(this System.Windows.Window window)
+        {
+            return new WindowInteropHelper(window).Handle;
+        }
+
+        #region WinAPI
+
+        const int WS_EX_TOOLWINDOW = 0x00000080;
+        const int WS_EX_NOACTIVATE = 0x08000000;
+        const int WS_EX_TRANSPARENT = 0x20;
+        const int GWL_EXSTYLE = -20;
+
+        const uint SWP_NOMOVE = 0x0002;
+        const uint SWP_NOSIZE = 0x0001;
+        const uint SWP_NOACTIVATE = 0x0010;
+        static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
+        static readonly IntPtr HWND_NOTOPMOST = new IntPtr(-2);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowPos")]
+        static extern bool WA_SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+        static extern int WA_SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
+        static extern int WA_GetWindowLong(IntPtr hWnd, int nIndex);
+
+        #endregion
+
+        static void UpdateWindowLong(IntPtr hwnd, bool isEnabled, int updateWith)
+        {
+            if (isEnabled)
+                WA_SetWindowLong(hwnd, GWL_EXSTYLE, WA_GetWindowLong(hwnd, GWL_EXSTYLE) | updateWith);
+            else
+                WA_SetWindowLong(hwnd, GWL_EXSTYLE, WA_GetWindowLong(hwnd, GWL_EXSTYLE) & ~updateWith);
+        }
+
+        /// <summary>
+        /// Remove a window from the window switching menu (Alt+Tab, Win + Tab)<br/>
+        /// For XAML it is better to use <c>ShowInTaskbar="False"</c><br/>
+        /// https://stackoverflow.com/a/551847/8980874
+        /// </summary>
+        public static void SetWindowHideFromAltTab(IntPtr hwnd, bool isEnabled)
+        {
+            UpdateWindowLong(hwnd, isEnabled, WS_EX_TOOLWINDOW);
+        }
+
+        /// <summary>
+        /// Make the mouse pass through the window
+        /// </summary>
+        /// <param name="hwnd"></param>
+        /// <param name="isEnabled"></param>
+        public static void SetWindowIgnoreMouse(IntPtr hwnd, bool isEnabled)
+        {
+            UpdateWindowLong(hwnd, isEnabled, WS_EX_TRANSPARENT);
+        }
+
+        /// <summary>
+        /// Allows the game window not to lose focus when clicking on <paramref name="hwnd"/> window.<br/>
+        /// Parameters in XAML don't have the same effect.
+        /// <br/><br/>
+        /// For example, in Crysis 3, when a window is clicked,<br/>
+        /// the sound is interrupted if only the parameters in XAML are used.<br/>
+        /// But if use this method, then the parameters in XAML are not needed.
+        /// </summary>
+        /// <param name="hwnd"></param>
+        /// <param name="isEnabled"></param>
+        public static void SetWindowIgnoreFocus(IntPtr hwnd, bool isEnabled)
+        {
+            UpdateWindowLong(hwnd, isEnabled, WS_EX_NOACTIVATE);
+        }
+
+        /// <summary>
+        /// Set the window as topmost permanently
+        /// </summary>
+        /// <param name="hwnd"></param>
+        /// <param name="fAlwaysTop"></param>
+        public static void SetWindowTopmost(IntPtr hwnd, bool fAlwaysTop)
+        {
+            IntPtr hwndIdx = fAlwaysTop ? HWND_TOPMOST : HWND_NOTOPMOST;
+            WA_SetWindowPos(hwnd, hwndIdx, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
+    }
+}


### PR DESCRIPTION
Added ClickThrough parameter for notification windows Added a permanent Topmost flag for notification windows Removed the ability to focus notification windows
Fixed a crash if the balloon in the tray had too long text